### PR TITLE
Add Landsat ML cookbook to gallery

### DIFF
--- a/site/cookbook_gallery.txt
+++ b/site/cookbook_gallery.txt
@@ -3,3 +3,4 @@ cmip6-cookbook
 HRRR-AWS-cookbook
 radar-cookbook
 intake-cookbook
+landsat-ml-cookbook


### PR DESCRIPTION
I think the [Landsat ML Cookbook](https://github.com/ProjectPythia/landsat-ml-cookbook) is ready to be added to the gallery.
