### PR TITLE
Generate and use token from GH App

### DIFF
--- a/.github/workflows/update-cookbook-gallery.yaml
+++ b/.github/workflows/update-cookbook-gallery.yaml
@@ -110,6 +110,12 @@ jobs:
           python -m pre_commit run --all-files
           exit 0
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v4
@@ -122,7 +128,7 @@ jobs:
           title: 'Update cookbook gallery per #${{ github.event.issue.number }}'
           body: |
             Update cookbook gallery as requested in #${{ github.event.issue.number }}. Closes #${{ github.event.issue.number }}.
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           branch: cookbook-gallery-${{ github.event.issue.number }}
 
       - name: Find Comment


### PR DESCRIPTION
We currently rely on individual users' Personal Access Tokens (PATs) in place of the default `GITHUB_TOKEN` for our workflows that submit PRs that themselves kick off additional workflows (a [documented limitation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) of `GITHUB_TOKEN`.) PATs can be somewhat flimsy and risky, especially as collaborators come and go, and requires individuals to task themselves with generating and updating these secrets.

Owners can see in the Pythia Organization settings that I've created a new `Pythia PR Machine` Github App. This app has the appropriate (and limited) access to our org and this repo to generate tokens that should work for these workflows. The app must be installed to the particular repo where the token is needed, and appropriate app secrets must be provisioned in the settings. If this works as intended, I'll document that process for other org owners.

I haven't recreated the machinery elsewhere to test this elsewhere; I figure we review and merge this, and we can test this as part of submitting `gridding-cookbook` to the gallery.