### PR TITLE
Gridding-Cookbook seems to be breaking the Cookbook Gallery Deployment

### DIFF
--- a/site/cookbook_gallery.txt
+++ b/site/cookbook_gallery.txt
@@ -4,6 +4,5 @@ HRRR-AWS-cookbook
 radar-cookbook
 intake-cookbook
 landsat-ml-cookbook
-gridding-cookbook
 kerchunk-cookbook
 xbatcher-ML-1-cookbook


### PR DESCRIPTION
Will investigate more why this one [gridding-cookbook](https://github.com/ProjectPythia/gridding-cookbook) is causing the build to fail. There must be some field we are requesting that is in all other cookbooks but not this one?

Locally my site builds without this repo listed, and fails with the same error we're seeing upstream if it is listed.