### PR TITLE
Change Cookbook-gallery automation

### DIFF
--- a/.github/workflows/update-cookbook-gallery.yaml
+++ b/.github/workflows/update-cookbook-gallery.yaml
@@ -7,7 +7,7 @@ on:
       - edited
 jobs:
   validate-user-submission:
-    if: github.repository == 'ProjectPythia/cookbook-gallery' && contains(github.event.issue.labels.*.name, 'cookbook-gallery-submission')
+    if: github.repository == 'ProjectPythia/cookbook-gallery' && github.event.issue.title == 'Update Gallery with new Cookbook'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Changing the line that looks for an issue label that is not automatically applied to issues made from the template, instead looks for issues that share the name that the template gives them. 
