### PR TITLE
Fix nightly build badge links

### DIFF
--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -179,7 +179,6 @@ def build_from_repos(
         repo = repo_dict["repo"]
         github_url = repo_dict["github_url"]
         status_badges = _generate_status_badge_html(repo, github_url)
-        print(status_badges)
 
         cookbook_url = repo_dict["cookbook_url"]
         cookbook_title = repo_dict["cookbook_title"]

--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -179,6 +179,7 @@ def build_from_repos(
         repo = repo_dict["repo"]
         github_url = repo_dict["github_url"]
         status_badges = _generate_status_badge_html(repo, github_url)
+        print(status_badges)
 
         cookbook_url = repo_dict["cookbook_url"]
         cookbook_title = repo_dict["cookbook_title"]
@@ -240,7 +241,7 @@ def build_from_repos(
 +++
 <div class="tagsandbadges">
 {tags}
-<div{status_badges}</div>
+<div>{status_badges}</div>
 </div>
 
 """


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Resolves #134 

This PR fixes a bug in the gallery html code that prevented web links being embedded in the nightly-build badges displayed on the gallery.