### PR TITLE
Fix handling of long gallery card descriptions

### DIFF
--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -221,30 +221,31 @@ def build_from_repos(
             modal_str = '\n'.join([m.lstrip() for m in modal_str.split('\n')])
         else:
             modal_str = ""
-            new_card = f"""\
-                        :::{{grid-item-card}}
-                        :shadow: md
-                        :class-footer: card-footer
-                        <div class="d-flex gallery-card">
-                        <img src="{thumbnail_url}" class="gallery-thumbnail" />
-                        <div class="container">
-                        <a href="{cookbook_url}" class="text-decoration-none"><h4 class="display-4 p-0">{cookbook_title}</h4></a>
-                        <p class="card-subtitle">{authors_str}</p>
-                        <p class="my-2">{short_description} </p>
-                        </div>
-                        </div>
-                        {modal_str}
-                        
-                        +++
-                        
-                        <div class="tagsandbadges">
-                            {tags}
-                            <div>{status_badges}</div>
-                        </div>
-                        
-                        :::
+            
+        new_card = f"""\
+                    :::{{grid-item-card}}
+                    :shadow: md
+                    :class-footer: card-footer
+                    <div class="d-flex gallery-card">
+                    <img src="{thumbnail_url}" class="gallery-thumbnail" />
+                    <div class="container">
+                    <a href="{cookbook_url}" class="text-decoration-none"><h4 class="display-4 p-0">{cookbook_title}</h4></a>
+                    <p class="card-subtitle">{authors_str}</p>
+                    <p class="my-2">{short_description} </p>
+                    </div>
+                    </div>
+                    {modal_str}
+                    
+                    +++
+                    
+                    <div class="tagsandbadges">
+                        {tags}
+                        <div>{status_badges}</div>
+                    </div>
+                    
+                    :::
 
-                        """
+                    """
 
         grid_body.append('\n'.join([m.lstrip() for m in new_card.split('\n')]))
 


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Closes #201 

The reason that the Vapor Cookbook is not showing up in the gallery (and the Regridding Cookbook is duplicated) is that its description is long enough to trigger a truncation operation ([this line in `gallery_generator.py`](https://github.com/ProjectPythia/cookbook-gallery/blob/4ce228de4f617d0c11c72c77551f6b2e09136ad1/site/_extensions/gallery_generator.py#L208)).

This PR fixes a bug in that logic. The code for new card generation was in the `else` block of that statement, so did not execute for any cookbook whose description requires truncation. The card from the previous iteration (in this case, the Regridding Cookbook) was added to the gallery again instead.

Moving the new card generation code outside of the `if, else` block seems to solve the issue.