### PR TITLE
Remove unsightly ========= from gallery page

### DIFF
--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -256,7 +256,6 @@ def build_from_repos(
 
     grid = f"""
         # {title}
-        {'=' * len(title)}
         
         {stitle}
         {stext}


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This should get rid of the extra line below the title