### PR TITLE
Handle path to myst.yml more robustly

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -12,9 +12,6 @@ jobs:
     with:
         base_url: ''
         path_to_notebooks: docs
-        # The site is in docs/, but cookbook-actions zips & deploys _build/html from
-        # the repo root — so build in docs/ and move the output up to match.
-        build_command: 'myst build --execute --html && mv _build ..'
 
   deploy:
     needs: build

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -11,9 +11,10 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
         base_url: ''
-        # Build the docs/ site, then move its output to the repo-root _build/html
-        # that cookbook-actions zips & deploys.
-        build_command: 'cd docs && myst build --execute --html && mv _build ..'
+        path_to_notebooks: docs
+        # The site is in docs/, but cookbook-actions zips & deploys _build/html from
+        # the repo root — so build in docs/ and move the output up to match.
+        build_command: 'myst build --execute --html && mv _build ..'
 
   deploy:
     needs: build

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -12,9 +12,10 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
         base_url: ''
-        # Build the docs/ site, then move its output to the repo-root _build/html
-        # that cookbook-actions zips & deploys.
-        build_command: 'cd docs && myst build --execute --html && mv _build ..'
+        path_to_notebooks: docs
+        # The site is in docs/, but cookbook-actions zips & deploys _build/html from
+        # the repo root — so build in docs/ and move the output up to match.
+        build_command: 'myst build --execute --html && mv _build ..'
 
   deploy:
     needs: build

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -13,9 +13,6 @@ jobs:
     with:
         base_url: ''
         path_to_notebooks: docs
-        # The site is in docs/, but cookbook-actions zips & deploys _build/html from
-        # the repo root — so build in docs/ and move the output up to match.
-        build_command: 'myst build --execute --html && mv _build ..'
 
   deploy:
     needs: build

--- a/.github/workflows/trigger-site-build.yaml
+++ b/.github/workflows/trigger-site-build.yaml
@@ -9,6 +9,3 @@ jobs:
       artifact_name: book-zip-${{ github.event.number }}
       base_url: '/_preview/${{ github.event.number }}'
       path_to_notebooks: docs
-      # The site is in docs/, but cookbook-actions zips & deploys _build/html from
-      # the repo root — so build in docs/ and move the output up to match.
-      build_command: 'myst build --execute --html && mv _build ..'

--- a/.github/workflows/trigger-site-build.yaml
+++ b/.github/workflows/trigger-site-build.yaml
@@ -8,6 +8,7 @@ jobs:
     with:
       artifact_name: book-zip-${{ github.event.number }}
       base_url: '/_preview/${{ github.event.number }}'
+      path_to_notebooks: docs
       # The site is in docs/, but cookbook-actions zips & deploys _build/html from
       # the repo root — so build in docs/ and move the output up to match.
-      build_command: 'cd docs && myst build --execute --html && mv _build ..'
+      build_command: 'myst build --execute --html && mv _build ..'


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Closes #43 

This cleans up the workflow code to use the `path_to_notebooks:` input argument as intended.